### PR TITLE
Fully implement Last Player Alive Broadcasts/Cassie

### DIFF
--- a/AutoBroadcast.csproj
+++ b/AutoBroadcast.csproj
@@ -17,12 +17,8 @@
 	<ItemGroup>
 		<Reference Include="Assembly-CSharp-firstpass" HintPath="$(EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll" />
 		<Reference Include="Mirror" HintPath="$(EXILED_REFERENCES)\Mirror.dll" />
-		<Reference Include="UnityEngine.CoreModule">
-		  <HintPath>..\..\EXILED References\Master\UnityEngine.CoreModule.dll</HintPath>
-		</Reference>
-		<Reference Include="UnityEngine.PhysicsModule">
-		  <HintPath>..\..\EXILED References\Master\UnityEngine.PhysicsModule.dll</HintPath>
-		</Reference>
+		<Reference Include="UnityEngine.CoreModule" HintPath ="$(EXILED_REFERENCES)\UnityEngine.CoreModule.dll" />
+		<Reference Include="UnityEngine.PhysicsModule" HintPath="$(EXILED_REFERENCES)\UnityEngine.PhysicsModule.dll" />
 	</ItemGroup>
 
 </Project>

--- a/AutoBroadcast.csproj
+++ b/AutoBroadcast.csproj
@@ -10,14 +10,19 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="EXILED" Version="8.4.3" />
+		<PackageReference Include="EXILED" Version="8.8.0" />
 		<PackageReference Include="Lib.Harmony" Version="2.2.2" />
-		<PackageReference Include="UnityEngine.Modules" Version="2019.4.15" IncludeAssets="compile" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp-firstpass" HintPath="$(EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll"/>
-		<Reference Include="Mirror" HintPath="$(EXILED_REFERENCES)\Mirror.dll"/>
+		<Reference Include="Assembly-CSharp-firstpass" HintPath="$(EXILED_REFERENCES)\Assembly-CSharp-firstpass.dll" />
+		<Reference Include="Mirror" HintPath="$(EXILED_REFERENCES)\Mirror.dll" />
+		<Reference Include="UnityEngine.CoreModule">
+		  <HintPath>..\..\EXILED References\Master\UnityEngine.CoreModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.PhysicsModule">
+		  <HintPath>..\..\EXILED References\Master\UnityEngine.PhysicsModule.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
 </Project>

--- a/Config.cs
+++ b/Config.cs
@@ -39,6 +39,18 @@ public class Config : IConfig
 			Message = "Containment breach detected",
 		}
 	};
+	
+	public BroadCassie? LastPlayerOnTeam { get; set; } = new()
+	{
+		Broadcast = new()
+		{
+			Message = "There is one {role} remaining!",
+		},
+		Cassie = new()
+		{
+			Message = "There is 1 {role} remaining"
+		}
+	};
 
 	public Dictionary<int, BroadCassie> Delayed { get; set; } = new()
 	{

--- a/Handler.cs
+++ b/Handler.cs
@@ -136,6 +136,8 @@ public class Handler
 
 	public void OnDying(DyingEventArgs ev)
 	{
+		if (ev.Player == null) return;
+
 		// Makes sure the player is not an SCP/other class
 		if (ev.Player.Role.Team != Team.SCPs && ev.Player.Role.Team != Team.OtherAlive)
 		{

--- a/Objects.cs
+++ b/Objects.cs
@@ -1,4 +1,5 @@
 ﻿using Exiled.API.Features;
+using PlayerRoles;
 using System.ComponentModel;
 
 namespace AutoBroadcastSystem;
@@ -31,10 +32,19 @@ public class BroadcastSystem
 	public void Show(Player player)
 	{
 		if (UseHints)
-				player.ShowHint(Message, Duration);
+			player.ShowHint(Message, Duration);
 		else 
 			player.Broadcast(Duration, Message, default, Override); 
 	}
+
+    // Overload for displaying player role (Last Player Alive)
+    public void Show(RoleTypeId role)
+	{
+        if (UseHints)
+            Map.ShowHint(Message.Replace("{role}", HelperMethods.CassieRoleTranslations(role)), Duration);
+        else
+            Map.Broadcast(Duration, Message.Replace("{role}", HelperMethods.CassieRoleTranslations(role)), default, Override);
+    }
 }
 
 public class CassieBroadcast
@@ -49,8 +59,45 @@ public class CassieBroadcast
 	public void Send()
 	{
 		Cassie.MessageTranslated(
-			Message, 
-			Translation.IsEmpty() ? Message : Translation, 
+			Message,
+			Translation.IsEmpty() ? Message : Translation,
 			isSubtitles: ShowSubtitles);
 	}
+
+    // Overload for displaying player role (Last Player Alive)
+    public void Send(RoleTypeId role)
+	{
+        Cassie.MessageTranslated(
+            Message.Replace("{role}", HelperMethods.CassieRoleTranslations(role)),
+            Translation.IsEmpty() ? Message.Replace("{role}", HelperMethods.CassieRoleTranslations(role)) : Translation.Replace("{role}", HelperMethods.CassieRoleTranslations(role)),
+            isSubtitles: ShowSubtitles);
+    }
+}
+
+public static class HelperMethods
+{
+    public static string CassieRoleTranslations(RoleTypeId role)
+    {
+        switch (role)
+        {
+            case RoleTypeId.ClassD:
+                return "ClassD";
+            case RoleTypeId.Scientist:
+                return "Scientist";
+            case RoleTypeId.FacilityGuard:
+                return "Facility Guard";
+            case RoleTypeId.NtfCaptain:
+            case RoleTypeId.NtfSpecialist:
+            case RoleTypeId.NtfPrivate:
+            case RoleTypeId.NtfSergeant:
+                return "NineTailedFox";
+            case RoleTypeId.ChaosMarauder:
+            case RoleTypeId.ChaosConscript:
+            case RoleTypeId.ChaosRepressor:
+            case RoleTypeId.ChaosRifleman:
+                return "ChaosInsurgency";
+            default: // shouldnt really happen but it's there just in case
+                return "Not found";
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ chaos_announcement: null
 ntf_announcement_cassie_no_scps: 'DISABLED'
 ntf_announcement_cassie: 'DISABLED'
 round_start: null
+last_player_on_team: null
 timed: {}
 intervals: {}
 spawn_broadcasts: {}


### PR DESCRIPTION
Update to EXILED 8.8.0 (wasn't needed but updated it)

Fully implemented checks for last player alive. If there is only 1 player alive on a specified team, a configurable broadcast/cassie message is sent.

I had to add an extra method overload to Show() as part of the Object class, as I needed to access the player's role but also broadcast globally. As well as this, I added a helper method as part of the Object class in order to access a translatable word from the role given.